### PR TITLE
fix: use createWebHistory to change URL

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createMemoryHistory, createRouter } from 'vue-router'
+import { createWebHistory, createRouter } from 'vue-router'
 
 import AboutView from '../views/AboutView.vue'
 import HomeView from '../views/HomeView.vue'
@@ -11,7 +11,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createMemoryHistory(),
+  history: createWebHistory(),
   routes
 })
 


### PR DESCRIPTION
I should have read the docs more closely and not just copy paste code from it:
> The history option controls how routes are mapped onto URLs and vice versa. For the Playground example we're using createMemoryHistory(), which ignores the browser URL entirely and uses its own internal URL instead. That works well for the Playground, but it's unlikely to be what you'd want in a real application. Typically, you'd want to use createWebHistory() instead, or perhaps createWebHashHistory(). We'll cover that topic in more detail in the guide to [History modes](https://router.vuejs.org/guide/essentials/history-mode.html).

The URL now gets updated correctly.