### PR TITLE
fix: the `+` button in `Products` page has been moved next to the page title

### DIFF
--- a/frontend/pages/shop/changelog.vue
+++ b/frontend/pages/shop/changelog.vue
@@ -26,6 +26,9 @@ export default {
     data() {
         return {
             items: [{
+                date: "2024-07-11",
+                fixed: "Il pulsante per aggiungere nuovi prodotti è stato spostato in alto vicino alla scritta 'Prodotti'"
+            }, {
                 date: "2024-07-10",
                 added: ["Aggiunta pagina di login per gli utenti."]
             }, {

--- a/frontend/pages/shop/products/index.vue
+++ b/frontend/pages/shop/products/index.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-    <h1 class="h2">Prodotti</h1>
+    <h1 class="h2">Prodotti <NuxtLink :to="`/shop/products/new`"> <button type="button" class="btn btn-primary"><i
+            class="bi-plus-circle-fill" /></button></NuxtLink>
+    </h1>
   </div>
   <div class="table-responsive small">
     <table class="table table-striped table-sm">
@@ -8,9 +10,7 @@
         <tr>
           <th>Nome esposto</th>
           <th>Unità</th>
-          <th>
-            <NuxtLink :to="`/shop/products/new`"><i class="bi-plus-circle-fill" /></NuxtLink>
-          </th>
+          <th></th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Closes #32