### PR TITLE
fix: open sale details when clicking on the row and moved `+` button next to the title

### DIFF
--- a/frontend/pages/shop/changelog.vue
+++ b/frontend/pages/shop/changelog.vue
@@ -27,8 +27,14 @@ export default {
         return {
             items: [{
                 date: "2024-07-11",
-                added: ["Quando una vendita è creata con successo viene mostrato un avviso."],
-                fixed: ["Il pulsante per aggiungere nuovi prodotti è stato spostato in alto vicino alla scritta 'Prodotti'."]
+                added: [
+                    "Quando una vendita è creata con successo viene mostrato un avviso.",
+                    "Quando si clicca/preme sulla riga di una vendita apre la pagina di dettaglio."
+                ],
+                fixed: [
+                    "Il pulsante per aggiungere nuovi prodotti è stato spostato in alto vicino alla scritta 'Prodotti'.",
+                    "Il pulsante per aggiungere nuove vendite è stato spostato in alto vicino alla scritta 'Finestre di vendita'."
+                ]
             }, {
                 date: "2024-07-10",
                 added: ["Aggiunta pagina di login per gli utenti."]

--- a/frontend/pages/shop/sales/index.vue
+++ b/frontend/pages/shop/sales/index.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-    <h1 class="h2">Finestre di vendita</h1>
+    <h1 class="h2">Finestre di vendita <NuxtLink :to="`/shop/sales/new`"> <button type="button"
+          class="btn btn-primary"><i class="bi-plus-circle-fill" /></button></NuxtLink>
+    </h1>
   </div>
   <div class="table-responsive small">
     <table class="table table-striped table-sm">
@@ -10,21 +12,15 @@
           <th>Data inizio</th>
           <th>Data fine</th>
           <th>Stato</th>
-          <th>
-            <NuxtLink :to="`/shop/sales/new`"><i class="bi-plus-circle-fill" /></NuxtLink>
-          </th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="sale in sales" :key="sale.id">
+        <tr v-for="sale in sales" :key="sale.id" @click="rowClicked(sale.id)">
           <td>{{ sale.id }}</td>
           <td>{{ sale.startDate.toLocaleString() }}</td>
           <td>{{ sale.endDate.toLocaleString() }}</td>
           <td>
             {{ isSaleActive(sale) ? "🟢 In corso" : "🔴 Conclusa" }}
-          </td>
-          <td>
-            <NuxtLink :to="`/shop/sales/${sale.id}`"><i class="bi-pencil-fill" /></NuxtLink>
           </td>
         </tr>
       </tbody>
@@ -50,6 +46,9 @@ export default {
     this.$loader.stopLoader();
   },
   methods: {
+    rowClicked(saleId: string) {
+      navigateTo(`/shop/sales/${saleId}`)
+    },
     isSaleActive(sale: Sale): boolean {
       const now = new Date();
       return now >= sale.startDate && now <= sale.endDate


### PR DESCRIPTION
Closes #37